### PR TITLE
Set ADC ACQTIME to 40us

### DIFF
--- a/ports/nrf/modules/machine/adc.c
+++ b/ports/nrf/modules/machine/adc.c
@@ -143,7 +143,7 @@ STATIC mp_obj_t machine_adc_make_new(const mp_obj_type_t *type, size_t n_args, s
         .resistor_n = NRF_SAADC_RESISTOR_DISABLED,
         .gain       = NRF_SAADC_GAIN1_4,
         .reference  = NRF_SAADC_REFERENCE_VDD4,
-        .acq_time   = NRF_SAADC_ACQTIME_3US,
+        .acq_time   = NRF_SAADC_ACQTIME_40US,
         .mode       = NRF_SAADC_MODE_SINGLE_ENDED,
         .burst      = NRF_SAADC_BURST_DISABLED,
         .pin_p      = 1 + self->id, // pin_p=0 is AIN0, pin_p=8 is AIN7


### PR DESCRIPTION
In the pinetime, the battery is connected with a 1MOhm resistor, so 3us
isn't enough to measure it.
The battery is the only place where the ADC is used in the pinetime, so
it's ok to hardcode the new value, but it'd be better to make it
configurable if contributing upstream.

Fixes https://github.com/daniel-thompson/wasp-os/issues/254

For more details see the same issue in infinitime:
https://github.com/InfiniTimeOrg/InfiniTime/pull/483